### PR TITLE
Fixed gnome bug 626770 (incorrect timezone for cities in Kazakhstan)

### DIFF
--- a/data/Locations.xml.in
+++ b/data/Locations.xml.in
@@ -4941,7 +4941,7 @@
         <!-- The capital of Kazakhstan -->
         <_name>Astana</_name>
         <coordinates>51.181111 71.427778</coordinates>
-        <tz-hint>Asia/Aqtobe</tz-hint>
+        <tz-hint>Asia/Almaty</tz-hint>
         <location>
           <name>Astana</name>
           <code>UACC</code>
@@ -4967,6 +4967,7 @@
           -->
         <_name>Qaraghandy</_name>
         <coordinates>49.798889 73.099444</coordinates>
+        <tz-hint>Asia/Almaty</tz-hint>
         <location>
           <name>Qaraghandy</name>
           <code>UAKK</code>
@@ -4979,7 +4980,7 @@
           -->
         <_name>Qostanay</_name>
         <coordinates>53.166667 63.583333</coordinates>
-        <tz-hint>Asia/Aqtobe</tz-hint>
+        <tz-hint>Asia/Almaty</tz-hint>
         <location>
           <name>Qostanay</name>
           <code>UAUU</code>
@@ -5003,7 +5004,7 @@
         <!-- A city in Kazakhstan -->
         <_name>Shymkent</_name>
         <coordinates>42.300000 69.600000</coordinates>
-        <tz-hint>Asia/Aqtobe</tz-hint>
+        <tz-hint>Asia/Almaty</tz-hint>
         <location>
           <name>Shymkent</name>
           <code>UAII</code>


### PR DESCRIPTION
Corrected zone hints for several cities in Kazakhstan fixing long standing bug: https://bugzilla.gnome.org/show_bug.cgi?id=626770