### PR TITLE
[updated] Fixed gnome bug 626770 (incorrect timezone for cities in Kazakhstan)

### DIFF
--- a/data/Locations.xml.in
+++ b/data/Locations.xml.in
@@ -4941,7 +4941,7 @@
         <!-- The capital of Kazakhstan -->
         <_name>Astana</_name>
         <coordinates>51.181111 71.427778</coordinates>
-        <tz-hint>Asia/Aqtobe</tz-hint>
+        <tz-hint>Asia/Almaty</tz-hint>
         <location>
           <name>Astana</name>
           <code>UACC</code>
@@ -4967,6 +4967,7 @@
           -->
         <_name>Qaraghandy</_name>
         <coordinates>49.798889 73.099444</coordinates>
+        <tz-hint>Asia/Almaty</tz-hint>
         <location>
           <name>Qaraghandy</name>
           <code>UAKK</code>
@@ -4979,7 +4980,7 @@
           -->
         <_name>Qostanay</_name>
         <coordinates>53.166667 63.583333</coordinates>
-        <tz-hint>Asia/Aqtobe</tz-hint>
+        <tz-hint>Asia/Almaty</tz-hint>
         <location>
           <name>Qostanay</name>
           <code>UAUU</code>
@@ -5003,7 +5004,7 @@
         <!-- A city in Kazakhstan -->
         <_name>Shymkent</_name>
         <coordinates>42.300000 69.600000</coordinates>
-        <tz-hint>Asia/Aqtobe</tz-hint>
+        <tz-hint>Asia/Almaty</tz-hint>
         <location>
           <name>Shymkent</name>
           <code>UAII</code>

--- a/data/Locations.xml.in
+++ b/data/Locations.xml.in
@@ -4941,7 +4941,6 @@
         <!-- The capital of Kazakhstan -->
         <_name>Astana</_name>
         <coordinates>51.181111 71.427778</coordinates>
-        <tz-hint>Asia/Almaty</tz-hint>
         <location>
           <name>Astana</name>
           <code>UACC</code>
@@ -4967,7 +4966,6 @@
           -->
         <_name>Qaraghandy</_name>
         <coordinates>49.798889 73.099444</coordinates>
-        <tz-hint>Asia/Almaty</tz-hint>
         <location>
           <name>Qaraghandy</name>
           <code>UAKK</code>
@@ -4980,7 +4978,6 @@
           -->
         <_name>Qostanay</_name>
         <coordinates>53.166667 63.583333</coordinates>
-        <tz-hint>Asia/Almaty</tz-hint>
         <location>
           <name>Qostanay</name>
           <code>UAUU</code>
@@ -4993,7 +4990,6 @@
           -->
         <_name>Qyzylorda</_name>
         <coordinates>44.852778 65.509167</coordinates>
-        <tz-hint>Asia/Almaty</tz-hint>
         <location>
           <name>Qyzylorda</name>
           <code>UAOO</code>
@@ -5004,7 +5000,6 @@
         <!-- A city in Kazakhstan -->
         <_name>Shymkent</_name>
         <coordinates>42.300000 69.600000</coordinates>
-        <tz-hint>Asia/Almaty</tz-hint>
         <location>
           <name>Shymkent</name>
           <code>UAII</code>


### PR DESCRIPTION
Fixing bug 626770. After reading the README for Locations.xml.in, I simply removed tzhint from cities whose timezone is the same as the default for the country.